### PR TITLE
refactor: move skill to standard skills/<name>/ layout

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "search-flights",
       "source": "./.",
       "description": "Search and compare flight prices using Google Flights data — bilingual Chinese/English",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "author": {
         "name": "pierrelzw"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,10 +1,9 @@
 {
   "name": "search-flights",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Search and compare flight prices using Google Flights data — bilingual Chinese/English",
   "author": { "name": "pierrelzw" },
   "repository": "https://github.com/pierrelzw/search-flights",
   "license": "MIT",
-  "keywords": ["flights", "travel", "google-flights", "price-comparison", "bilingual"],
-  "skills": ["./SKILL.md"]
+  "keywords": ["flights", "travel", "google-flights", "price-comparison", "bilingual"]
 }

--- a/setup.sh
+++ b/setup.sh
@@ -10,6 +10,3 @@ echo "Installing dependencies..."
 
 echo ""
 echo "Setup complete!"
-echo ""
-echo "To use this skill in Claude Code, symlink it:"
-echo "  ln -s $(pwd) ~/.claude/skills/search-flights"

--- a/skills/search-flights/SKILL.md
+++ b/skills/search-flights/SKILL.md
@@ -7,7 +7,7 @@ description: |
   "回国机票", "买票", "订机票", or wants to compare flight prices.
 user-invocable: true
 allowed-tools:
-  - Bash(cd ${CLAUDE_SKILL_DIR} && bash run.sh *)
+  - Bash(cd ${CLAUDE_PLUGIN_ROOT} && bash run.sh *)
 argument-hint: "<natural language flight search request>"
 ---
 
@@ -31,7 +31,7 @@ The user can describe their needs in **natural language** (Chinese or English). 
 ### 1. Flexible Date Range (compare across dates)
 When the user gives a travel window and trip duration range:
 ```bash
-cd ${CLAUDE_SKILL_DIR} && bash run.sh \
+cd ${CLAUDE_PLUGIN_ROOT} && bash run.sh \
   <origin> <destination> \
   --from <YYYY-MM-DD> --to <YYYY-MM-DD> \
   --min-days <N> --max-days <N> \
@@ -41,7 +41,7 @@ cd ${CLAUDE_SKILL_DIR} && bash run.sh \
 ### 2. Exact Dates (specific departure and return)
 When the user specifies exact travel dates:
 ```bash
-cd ${CLAUDE_SKILL_DIR} && bash run.sh \
+cd ${CLAUDE_PLUGIN_ROOT} && bash run.sh \
   <origin> <destination> \
   --depart <YYYY-MM-DD> --return <YYYY-MM-DD> \
   [--max-stops <N>] [--top <N>]
@@ -50,7 +50,7 @@ cd ${CLAUDE_SKILL_DIR} && bash run.sh \
 ### 3. One-Way
 When the user wants a one-way flight:
 ```bash
-cd ${CLAUDE_SKILL_DIR} && bash run.sh \
+cd ${CLAUDE_PLUGIN_ROOT} && bash run.sh \
   <origin> <destination> \
   --depart <YYYY-MM-DD> --one-way \
   [--max-stops <N>] [--top <N>]


### PR DESCRIPTION
## Summary

Move skill files from repo root into `skills/search-flights/` so the skill follows the official Claude Code convention.

## Motivation

Per [official docs](https://code.claude.com/docs/en/skills.md): "Custom commands have been merged into skills. A file at `.claude/commands/deploy.md` and a skill at `.claude/skills/deploy/SKILL.md` both create `/deploy` and work the same way."

Root-level `SKILL.md` with `"skills": ["./SKILL.md"]` in plugin.json only registers the skill for natural-language trigger — it does **not** create a `/<plugin>:<skill>` slash command. Standard `skills/<name>/SKILL.md` layout gets both.

## Changes

- Move `SKILL.md`, `run.sh`, `setup.sh`, `scripts/`, `tests/`, `requirements.txt` → `skills/search-flights/`
- Drop `"skills": [...]` field from plugin.json (auto-discovery)
- Bump version 0.1.1 → 0.1.2
- Sync `.claude-plugin/marketplace.json` version

## Notes

- `${CLAUDE_SKILL_DIR}` references in SKILL.md continue to work — Claude Code resolves it to the skill dir, which moves with the files.
- The `feat/flyai-fallback` branch (#5) will be rebased onto this layout post-merge.

## Test plan

- [ ] After merge: bump zhiwei-skills hub marketplace.json to 0.1.2
- [ ] `/plugin marketplace update pierrelzw` + `/plugin install search-flights@pierrelzw`
- [ ] Verify `/search-flights:search-flights` appears in `/` menu
- [ ] Verify natural-language trigger still works ("搜机票", etc.)